### PR TITLE
Add support for top-level message blocks

### DIFF
--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -22,6 +22,35 @@ class SlackWebhookChannel extends LaravelSlackWebhookChannel
     }
 
     /**
+     * Build up a JSON payload for the Slack webhook.
+     *
+     * @param  \Illuminate\Notifications\Messages\SlackMessage  $message
+     * @return array
+     */
+    protected function buildJsonPayload(SlackMessage $message)
+    {
+        $optionalFields = array_filter([
+            'channel' => data_get($message, 'channel'),
+            'icon_emoji' => data_get($message, 'icon'),
+            'icon_url' => data_get($message, 'image'),
+            'link_names' => data_get($message, 'linkNames'),
+            'unfurl_links' => data_get($message, 'unfurlLinks'),
+            'unfurl_media' => data_get($message, 'unfurlMedia'),
+            'username' => data_get($message, 'username'),
+        ]);
+
+        $result = array_merge([
+            'json' => array_merge([
+                'text' => $message->content,
+                'blocks' => $this->blocks($message),
+                'attachments' => $this->attachments($message),
+            ], $optionalFields),
+        ], $message->http);
+
+        return $result;
+    }
+
+    /**
      * Format the message's attachments.
      *
      * @param  \Illuminate\Notifications\Messages\SlackMessage  $message
@@ -54,14 +83,14 @@ class SlackWebhookChannel extends LaravelSlackWebhookChannel
     }
 
     /**
-     * Format the attachment's blocks.
+     * Format the message's blocks.
      *
-     * @param  \NathanHeffley\LaravelSlackBlocks\Messages\SlackBlockContract  $attachment
+     * @param  SlackMessage|SlackAttachment  $message
      * @return array
      */
-    protected function blocks(SlackAttachment $attachment)
+    protected function blocks($message)
     {
-        return collect($attachment->blocks)->map(function (SlackBlockContract $value) {
+        return collect($message->blocks)->map(function (SlackBlockContract $value) {
             return $value->toArray();
         })->values()->all();
     }

--- a/src/Channels/SlackWebhookChannel.php
+++ b/src/Channels/SlackWebhookChannel.php
@@ -5,7 +5,7 @@ namespace NathanHeffley\LaravelSlackBlocks\Channels;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Notifications\Messages\SlackMessage;
 use NathanHeffley\LaravelSlackBlocks\Messages\SlackAttachment;
-use NathanHeffley\LaravelSlackBlocks\Contracts\SlackAttachmentBlockContract;
+use NathanHeffley\LaravelSlackBlocks\Contracts\SlackBlockContract;
 use Illuminate\Notifications\Channels\SlackWebhookChannel as LaravelSlackWebhookChannel;
 
 class SlackWebhookChannel extends LaravelSlackWebhookChannel
@@ -56,12 +56,12 @@ class SlackWebhookChannel extends LaravelSlackWebhookChannel
     /**
      * Format the attachment's blocks.
      *
-     * @param  \NathanHeffley\LaravelSlackBlocks\Messages\SlackAttachmentBlockContract  $attachment
+     * @param  \NathanHeffley\LaravelSlackBlocks\Messages\SlackBlockContract  $attachment
      * @return array
      */
     protected function blocks(SlackAttachment $attachment)
     {
-        return collect($attachment->blocks)->map(function (SlackAttachmentBlockContract $value) {
+        return collect($attachment->blocks)->map(function (SlackBlockContract $value) {
             return $value->toArray();
         })->values()->all();
     }

--- a/src/Contracts/SlackBlockContract.php
+++ b/src/Contracts/SlackBlockContract.php
@@ -2,10 +2,10 @@
 
 namespace NathanHeffley\LaravelSlackBlocks\Contracts;
 
-interface SlackAttachmentBlockContract
+interface SlackBlockContract
 {
     /**
-     * Get the array representation of the attachment block.
+     * Get the array representation of the block.
      *
      * @return array
      */

--- a/src/Messages/SlackAttachment.php
+++ b/src/Messages/SlackAttachment.php
@@ -22,7 +22,7 @@ class SlackAttachment extends LaravelSlackAttachment
      */
     public function block(Closure $callback)
     {
-        $this->blocks[] = $block = new SlackAttachmentBlock;
+        $this->blocks[] = $block = new SlackBlock;
 
         $callback($block);
 

--- a/src/Messages/SlackAttachmentBlockDivider.php
+++ b/src/Messages/SlackAttachmentBlockDivider.php
@@ -2,9 +2,9 @@
 
 namespace NathanHeffley\LaravelSlackBlocks\Messages;
 
-use NathanHeffley\LaravelSlackBlocks\Contracts\SlackAttachmentBlockContract;
+use NathanHeffley\LaravelSlackBlocks\Contracts\SlackBlockContract;
 
-class SlackAttachmentBlockDivider implements SlackAttachmentBlockContract
+class SlackAttachmentBlockDivider implements SlackBlockContract
 {
     /**
      * Get the array representation of the attachment block.

--- a/src/Messages/SlackAttachmentBlockImage.php
+++ b/src/Messages/SlackAttachmentBlockImage.php
@@ -2,9 +2,9 @@
 
 namespace NathanHeffley\LaravelSlackBlocks\Messages;
 
-use NathanHeffley\LaravelSlackBlocks\Contracts\SlackAttachmentBlockContract;
+use NathanHeffley\LaravelSlackBlocks\Contracts\SlackBlockContract;
 
-class SlackAttachmentBlockImage implements SlackAttachmentBlockContract
+class SlackAttachmentBlockImage implements SlackBlockContract
 {
     /**
      * The image's URL.

--- a/src/Messages/SlackBlock.php
+++ b/src/Messages/SlackBlock.php
@@ -42,6 +42,13 @@ class SlackBlock implements SlackBlockContract
     public $accessory;
 
     /**
+     * The url field of the block.
+     *
+     * @var string
+     */
+    public $url;
+
+    /**
      * The image url field of the block.
      *
      * @var string
@@ -130,6 +137,19 @@ class SlackBlock implements SlackBlockContract
     public function accessory($accessory)
     {
         $this->accessory = $accessory;
+
+        return $this;
+    }
+
+    /**
+     * Set the url of the block.
+     *
+     * @param  string  $url
+     * @return $this
+     */
+    public function url($url)
+    {
+        $this->$url = $url;
 
         return $this;
     }

--- a/src/Messages/SlackBlock.php
+++ b/src/Messages/SlackBlock.php
@@ -2,68 +2,68 @@
 
 namespace NathanHeffley\LaravelSlackBlocks\Messages;
 
-use NathanHeffley\LaravelSlackBlocks\Contracts\SlackAttachmentBlockContract;
+use NathanHeffley\LaravelSlackBlocks\Contracts\SlackBlockContract;
 
-class SlackAttachmentBlock implements SlackAttachmentBlockContract
+class SlackBlock implements SlackBlockContract
 {
     /**
-     * The type field of the attachment block.
+     * The type field of the block.
      *
      * @var string
      */
     public $type;
 
     /**
-     * The text field of the attachment block.
+     * The text field of the block.
      *
      * @var array
      */
     public $text;
 
     /**
-     * The block ID field of the attachment block.
+     * The block ID field of the block.
      *
      * @var string
      */
     public $id;
 
     /**
-     * The fields field of the attachment block.
+     * The fields field of the block.
      *
      * @var array
      */
     public $fields;
 
     /**
-     * The accessory field of the attachment block.
+     * The accessory field of the block.
      *
      * @var array
      */
     public $accessory;
 
     /**
-     * The image url field of the attachment block.
+     * The image url field of the block.
      *
      * @var string
      */
     public $imageUrl;
 
     /**
-     * The alt text field of the attachment block.
+     * The alt text field of the block.
      *
      * @var string
      */
     public $altText;
 
     /**
-     * The title field of the attachment block.
+     * The title field of the block.
      *
      * @var array
      */
     public $title;
 
     /**
-     * The elements field of the attachment block.
+     * The elements field of the block.
      *
      * @var array
      */
@@ -187,7 +187,7 @@ class SlackAttachmentBlock implements SlackAttachmentBlockContract
     }
 
     /**
-     * Get the array representation of the attachment block.
+     * Get the array representation of the block.
      *
      * @return array
      */

--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -4,9 +4,17 @@ namespace NathanHeffley\LaravelSlackBlocks\Messages;
 
 use Closure;
 use Illuminate\Notifications\Messages\SlackMessage as LaravelSlackMessage;
+use NathanHeffley\LaravelSlackBlocks\Messages\SlackBlock;
 
 class SlackMessage extends LaravelSlackMessage
 {
+    /**
+     * The message's blocks.
+     *
+     * @var array
+     */
+    public $blocks;
+
     /**
      * Define an attachment for the message.
      *
@@ -16,7 +24,24 @@ class SlackMessage extends LaravelSlackMessage
     public function attachment(Closure $callback)
     {
         $this->attachments[] = $attachment = new SlackAttachment;
+
         $callback($attachment);
+
+        return $this;
+    }
+
+    /**
+     * Add a block to the message.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function block(Closure $callback)
+    {
+        $this->blocks[] = $block = new SlackBlock;
+
+        $callback($block);
+
         return $this;
     }
 }

--- a/tests/NotificationSlackChannelTest.php
+++ b/tests/NotificationSlackChannelTest.php
@@ -66,6 +66,7 @@ class NotificationSlackChannelTest extends TestCase
             [
                 'json' => [
                     'text' => 'Content',
+                    'blocks' => [],
                     'attachments' => [
                         [
                             'title' => 'Laravel',
@@ -109,7 +110,7 @@ class NotificationSlackChannelTest extends TestCase
                                     'type' => 'actions',
                                     'elements' => [
                                         'type' => 'button',
-                                        "text" => [
+                                        'text' => [
                                             'type' => 'plain_text',
                                             'text' => 'Cancel',
                                         ],
@@ -130,6 +131,7 @@ class NotificationSlackChannelTest extends TestCase
             [
                 'json' => [
                     'text' => 'Content',
+                    'blocks' => [],
                     'attachments' => [
                         [
                             'title' => 'Specialty',
@@ -219,7 +221,7 @@ class NotificationSlackChannelWithAttachmentBlockBuilderTestNotification extends
                             ->type('actions')
                             ->elements([
                                 'type' => 'button',
-                                "text" => [
+                                'text' => [
                                     'type' => 'plain_text',
                                     'text' => 'Cancel',
                                 ],

--- a/tests/NotificationSlackChannelTest.php
+++ b/tests/NotificationSlackChannelTest.php
@@ -54,69 +54,71 @@ class NotificationSlackChannelTest extends TestCase
     public function payloadDataProvider()
     {
         return [
-            'payloadWithAttachmentBlockBuilder' => $this->getPayloadWithAttachmentBlockBuilder(),
+            'payloadWithAttachmentBlockBuilder' => $this->getPayloadWithMessageAndAttachmentBlockBuilder(),
             'payloadWithAttachmentSpecialtyBlockBuilder' => $this->getPayloadWithAttachmentSpecialtyBlockBuilder(),
         ];
     }
 
-    public function getPayloadWithAttachmentBlockBuilder()
+    public function getPayloadWithMessageAndAttachmentBlockBuilder()
     {
+        $blocks = [
+            [
+                'type' => 'section',
+                'text' => [
+                    'type' => 'plain_text',
+                    'text' => 'Laravel',
+                ],
+                'block_id' => 'block-one',
+                'fields' => [
+                    [
+                        'type' => 'mrkdwn',
+                        'text' => 'Block',
+                    ],
+                    [
+                        'type' => 'mrkdwn',
+                        'text' => 'Attachments',
+                    ],
+                ],
+                'accessory' => [
+                    'type' => 'datepicker',
+                ],
+            ],
+            [
+                'type' => 'divider',
+            ],
+            [
+                'type' => 'image',
+                'image_url' => 'https://placekitten.com/400/600',
+                'alt_text' => 'A cute little kitten',
+                'title' => [
+                    'type' => 'plain_text',
+                    'text' => 'Kitten picture',
+                ],
+            ],
+            [
+                'type' => 'actions',
+                'elements' => [
+                    'type' => 'button',
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'Cancel',
+                    ],
+                ],
+            ],
+        ];
+
         return [
             new NotificationSlackChannelWithAttachmentBlockBuilderTestNotification,
             [
                 'json' => [
                     'text' => 'Content',
-                    'blocks' => [],
+                    'blocks' => $blocks,
                     'attachments' => [
                         [
                             'title' => 'Laravel',
                             'text' => 'Attachment Content',
                             'title_link' => 'https://laravel.com',
-                            'blocks' => [
-                                [
-                                    'type' => 'section',
-                                    'text' => [
-                                        'type' => 'plain_text',
-                                        'text' => 'Laravel',
-                                    ],
-                                    'block_id' => 'block-one',
-                                    'fields' => [
-                                        [
-                                            'type' => 'mrkdwn',
-                                            'text' => 'Block',
-                                        ],
-                                        [
-                                            'type' => 'mrkdwn',
-                                            'text' => 'Attachments',
-                                        ],
-                                    ],
-                                    'accessory' => [
-                                        'type' => 'datepicker',
-                                    ],
-                                ],
-                                [
-                                    'type' => 'divider',
-                                ],
-                                [
-                                    'type' => 'image',
-                                    'image_url' => 'https://placekitten.com/400/600',
-                                    'alt_text' => 'A cute little kitten',
-                                    'title' => [
-                                        'type' => 'plain_text',
-                                        'text' => 'Kitten picture',
-                                    ],
-                                ],
-                                [
-                                    'type' => 'actions',
-                                    'elements' => [
-                                        'type' => 'button',
-                                        'text' => [
-                                            'type' => 'plain_text',
-                                            'text' => 'Cancel',
-                                        ],
-                                    ],
-                                ],
-                            ],
+                            'blocks' => $blocks,
                         ],
                     ],
                 ],
@@ -178,6 +180,52 @@ class NotificationSlackChannelWithAttachmentBlockBuilderTestNotification extends
     {
         return (new SlackMessage)
             ->content('Content')
+            ->block(function ($block) {
+                $block
+                    ->type('section')
+                    ->text([
+                        'type' => 'plain_text',
+                        'text' => 'Laravel',
+                    ])
+                    ->id('block-one')
+                    ->fields([
+                        [
+                            'type' => 'mrkdwn',
+                            'text' => 'Block',
+                        ],
+                        [
+                            'type' => 'mrkdwn',
+                            'text' => 'Attachments',
+                        ],
+                    ])
+                    ->accessory([
+                        'type' => 'datepicker',
+                    ]);
+            })
+            ->block(function ($block) {
+                $block->type('divider');
+            })
+            ->block(function ($block) {
+                $block
+                    ->type('image')
+                    ->imageUrl('https://placekitten.com/400/600')
+                    ->altText('A cute little kitten')
+                    ->title([
+                        'type' => 'plain_text',
+                        'text' => 'Kitten picture'
+                    ]);
+            })
+            ->block(function ($block) {
+                $block
+                    ->type('actions')
+                    ->elements([
+                        'type' => 'button',
+                        'text' => [
+                            'type' => 'plain_text',
+                            'text' => 'Cancel',
+                        ],
+                    ]);
+            })
             ->attachment(function ($attachment) {
                 $attachment->title('Laravel', 'https://laravel.com')
                     ->content('Attachment Content')


### PR DESCRIPTION
Hey there, thanks for this package! This PR adds support for blocks in top-level messages.
(Unrelated) it also adds support for the `url` field in blocks, so you can make buttons that link to external URLs.

I plan to use this in tightenco/ozzie#23 to add a button accessory block to a top-level message.

Changes include:
- Renamed `SlackAttachmentBlock` to `SlackBlock`
- Overrode Laravel's `buildJsonPayload` message in the Slack webhook class so we can add the `blocks` key to the top-level response
- Added a `$blocks` property to the Slack message class
- Updated the `blocks()` method in the Slack webhook class so it can accept either a `SlackMessage` or a `SlackAttachment` (parsing behavior is identical)