### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 composer.lock
 .DS_Store
 Thumbs.db
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "laravel/slack-notification-channel": "^2.0"
     },

--- a/tests/NotificationSlackChannelTest.php
+++ b/tests/NotificationSlackChannelTest.php
@@ -4,6 +4,7 @@ namespace NathanHeffley\Tests\LaravelSlackBlocks;
 
 use Mockery as m;
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
@@ -46,6 +47,8 @@ class NotificationSlackChannelTest extends TestCase
         $this->guzzleHttp->shouldReceive('post')->andReturnUsing(function ($argUrl, $argPayload) use ($payload) {
             $this->assertEquals('url', $argUrl);
             $this->assertEquals($payload, $argPayload);
+
+            return new Response();
         });
 
         $this->slackChannel->send(new NotificationSlackChannelTestNotifiable, $notification);

--- a/tests/NotificationSlackChannelTest.php
+++ b/tests/NotificationSlackChannelTest.php
@@ -22,7 +22,7 @@ class NotificationSlackChannelTest extends TestCase
      */
     private $guzzleHttp;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class NotificationSlackChannelTest extends TestCase
         $this->slackChannel = new SlackWebhookChannel($this->guzzleHttp);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }


### PR DESCRIPTION
This PR adds support for PHP 8 along with:

- Fixes for tests under PHPUnit 8+
- Fixes for tests using Guzzle 7
- Added `.phpunit.result.cache` to `.gitignore`